### PR TITLE
Fixed issues for blank cell in table footer and but…

### DIFF
--- a/GPS.Service/Pages/Index.cshtml
+++ b/GPS.Service/Pages/Index.cshtml
@@ -36,6 +36,7 @@
         </tbody>
         <tfoot>
             <tr>
+                <th>Tag Name</th>
                 <th>Vehicle ID</th>
                 <th>Number</th>
                 <th>Start Date</th>

--- a/GPS.Service/Pages/Index.cshtml.cs
+++ b/GPS.Service/Pages/Index.cshtml.cs
@@ -18,7 +18,7 @@ namespace GPS.WebApp.Pages
 
 		public IndexModel(ILogger<IndexModel> logger)
 		{
-			sofParser = new Parser("SOF\\validTest.sof");
+			sofParser = new Parser("SOF\\current.sof");
 			allOutages = sofParser.PopulateObjectsFromSof();
 			_logger = logger;
 		}

--- a/GPS.Service/wwwroot/css/site.css
+++ b/GPS.Service/wwwroot/css/site.css
@@ -60,7 +60,8 @@ html {
 
 body {
   /* Margin bottom by footer height */
-  margin-bottom: 60px;
+  /*Adding '!important' forces this assignment to override any other margin-bottom assignments*/
+  margin-bottom: 60px !important;
 }
 .footer {
   position: absolute;
@@ -68,4 +69,9 @@ body {
   width: 100%;
   white-space: nowrap;
   line-height: 60px; /* Vertically center the text there */
+}
+
+/*Changing the max-width fixed the problem of the table not centering. The table footer 'search' cells were too big for the container*/
+.mydatatable tfoot input{
+    max-width: 125px;
 }

--- a/GPS.Service/wwwroot/js/data-table.js
+++ b/GPS.Service/wwwroot/js/data-table.js
@@ -5,7 +5,7 @@
 
 $('.mydatatable tfoot th').each(function () {
     var title = $(this).text();
-    $(this).html('<input type="text" placeholder="Search ' + title + '" />');
+    $(this).html('<input type="text" placeholder="Search" />');
 });
 
 table.columns().every(function () {


### PR DESCRIPTION
*This pull request replaces my pull request from yesterday, 10/8. The pull request this is replacing was branched from a different branch than WebApp and had additional changes that I had not made.

This pull request should fix 3 issues from Gitlab: 
1. CRITICAL Front End - Get the proper number of outages to show
 In the IndexModel class that is being passed into Index.cshtml I changed the new Parser's file path argument from "SOF\\validTest.sof" to "SOF\\current.sof". (I talked with Hannah about this)

2. Front End - Fix formatting issues
In Index.cshtml I modified the <tfoot>'s <th> tags to match <thead>'s <th> tags. This solved the problem of having a blank cell on the bottom row. This change also returned the column search functionality that was originally part of the table. When the search functionality returned to the bottom cells of the table they expanded the row width to larger than the container's width. This caused the entire table to be offset to the right. To fix this issue, in site.css I added 'max-width: 150px' to '.mydatatable tfoot input'.

3. Front End - Click through pages even when 100 entries are showing
In site.css I added '!important' to body's 'margin-bottom' attribute. This overrides other CSS references to this attribute (the other references seem to be what was causing the issue of the page footer overlapping the page buttons at the bottom of the table). 