### PR TITLE
Modified code to show ' ' instead of 'Invalid date' if End Time data …

### DIFF
--- a/GPS.Service/Pages/Index.cshtml
+++ b/GPS.Service/Pages/Index.cshtml
@@ -13,10 +13,10 @@
                         Tag Name
                     </th>
                     <th>
-                        Satellite Vehicle ID
+                        SVID
                     </th>
                     <th>
-                        Satellite Vehicle Number
+                        SVN
                     </th>
                     <th>
                         Start Time

--- a/GPS.Service/wwwroot/js/data-table.js
+++ b/GPS.Service/wwwroot/js/data-table.js
@@ -24,9 +24,15 @@ function loadList() {
             { data: "tagName" },
             { data: "satelliteVehicleId" },
             { data: "satelliteVehicleNumber" },
-            //copied directly from Brayden's code, but it is not sorting correctly
             { data: "startTime", render: function (data) { return moment(data).format('M/D/YYYY HH:mm:ss'); } },
-            { data: "endTime", render: function (data) { return moment(data).format('M/D/YYYY HH:mm:ss'); } },
+            {
+                data: "endTime", render: function (data) {
+                    let momentEndDate = moment(data).format('M/D/YYYY HH:mm:ss');
+                    let endDate = (momentEndDate === 'Invalid date') ? '' : momentEndDate;
+                    
+                    return endDate;
+                }
+            },
             { data: "type" },
             { data: "reference" }
         ],


### PR DESCRIPTION
This branch's sorting works for the 'start date' and 'end date' columns. 

I also changed the code to show an empty string instead of "Invalid date" for cells with invalid date format (like the objects without an end date). 

I have not been able to figure out how to fix the sorting to show the 'invalid date' cells as most recent. They are sorting as oldest right now.